### PR TITLE
Use git worktrees for concurrent agent sessions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY main.py .
 RUN python3 -m pip install --break-system-packages .
 
 # Create data directory
-RUN mkdir -p /data/projects
+RUN mkdir -p /data/projects /data/worktrees
 
 # Configure Codex CLI for autonomous operation (no permission prompts)
 RUN mkdir -p /root/.codex && printf '%s\n' \

--- a/app/core/session_manager.py
+++ b/app/core/session_manager.py
@@ -420,7 +420,7 @@ class SessionManager:
         """Remove a session from tracking, clean up its worktree, and persist."""
         active = self._active_sessions.get(external_session_id)
         if active is not None:
-            await self._repo_provider.cleanup_worktree(active.cwd)
+            await self._repo_provider.cleanup_worktree(active.cwd, branch_name=active.branch_name)
             del self._active_sessions[external_session_id]
             self._save_sessions()
             logger.info("Removed session %s from tracking", external_session_id)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     volumes:
       # Project files
       - ./data/projects:/data/projects
+      # Git worktrees for concurrent agent sessions
+      - ./data/worktrees:/data/worktrees
       # Session metadata (persisted across restarts)
       - sessions-data:/var/lib/bridge
       # Claude Code session files (persisted across restarts)


### PR DESCRIPTION
## Summary
Replace git branch-based session isolation with git worktrees to enable true concurrent execution of multiple agent sessions without working-tree conflicts.

## Key Changes

- **RepoProvider**: 
  - Changed from creating branches in a single repo to creating isolated git worktrees for each session
  - Added `_worktrees_base` directory (`/data/worktrees`) to store session-specific worktrees
  - Updated `prepare_new_session()` to use `git worktree add` instead of `git checkout -B`
  - Updated `prepare_resume_session()` to accept optional `cwd` parameter and reuse existing worktrees when available
  - Added new `cleanup_worktree()` method to safely remove worktrees and prune stale entries
  - Added `_worktree_path_for()` helper to generate consistent worktree paths

- **SessionManager**:
  - Updated `prepare_resume_session()` call to pass the stored `cwd` for worktree reuse
  - Changed `remove_session()` to async and added worktree cleanup before removing session tracking
  - Ensures worktrees are properly cleaned up when sessions end

## Implementation Details

- Each session gets its own isolated worktree directory at `/data/worktrees/{repo}/{slug}-{timestamp}`
- Worktrees are created from the default branch (origin/main or origin/HEAD) with a session-specific branch
- Backward compatibility maintained: `prepare_resume_session()` falls back to checking out the branch in the main repo if no worktree path is provided
- Worktree cleanup is safe: skips the main repo path and handles both git-based and manual cleanup
- Thread-safe via existing asyncio.Lock during repo operations

https://claude.ai/code/session_014HHZ1AuxNekKXWsfBEnpgy