### PR TITLE
Add per-channel context/system prompts for Slack channels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,4 @@ SLACK_USER_TOKEN=xoxp-...             # User token for search API
 # SLACK_APP_TOKEN__CODEX=xapp-codex-app-token
 
 # SLACK_CHANNEL_REPOS={"C123":"owner/repo1","C456":"owner/repo2"}  # Per-channel repo overrides
+# SLACK_CHANNEL_PROMPTS={"C123":"You are debugging production alerts. Be concise and technical.","C456":"Explain things simply for non-technical users."}  # Per-channel context

--- a/app/config.py
+++ b/app/config.py
@@ -44,6 +44,7 @@ class Settings(BaseSettings):
     slack_bot_token: str = ""  # Bot token (xoxb-...) for Web API
     slack_user_token: str = ""  # User token (xoxp-...) for search API
     slack_channel_repos: str = ""  # JSON: {"C123": "owner/repo", "C456": "owner/repo2"}
+    slack_channel_prompts: str = ""  # JSON: {"C123": "You are debugging alerts.", ...}
 
     # GitHub
     github_app_id: str = ""
@@ -113,6 +114,19 @@ class Settings(BaseSettings):
             return {}
         try:
             mapping = json.loads(self.slack_channel_repos)
+            if not isinstance(mapping, dict):
+                return {}
+            return {str(k): str(v) for k, v in mapping.items()}
+        except (json.JSONDecodeError, TypeError):
+            return {}
+
+    @property
+    def parsed_slack_channel_prompts(self) -> dict[str, str]:
+        """Parse SLACK_CHANNEL_PROMPTS JSON into a channel_id -> prompt mapping."""
+        if not self.slack_channel_prompts:
+            return {}
+        try:
+            mapping = json.loads(self.slack_channel_prompts)
             if not isinstance(mapping, dict):
                 return {}
             return {str(k): str(v) for k, v in mapping.items()}

--- a/app/services/slack/adapter.py
+++ b/app/services/slack/adapter.py
@@ -283,11 +283,16 @@ class SlackAdapter:
         channel_repos = settings.parsed_slack_channel_repos
         channel_repo = channel_repos.get(mention_event.channel, "")
 
+        # Prepend channel-specific context to the prompt if configured
+        channel_prompts = settings.parsed_slack_channel_prompts
+        channel_context = channel_prompts.get(mention_event.channel, "")
+        full_prompt = f"{channel_context}\n\n{prompt}" if channel_context else prompt
+
         # Create bridge request
         request = BridgeSessionRequest(
             external_session_id=session_id,
             service_name=self.service_name,
-            prompt=thread_context + prompt,
+            prompt=thread_context + full_prompt,
             agent_name=self._agent_name,
             descriptive_name=slugify(prompt[:60]),
             service_metadata=session_data,


### PR DESCRIPTION
  Adds SLACK_CHANNEL_PROMPTS config — a JSON mapping of Slack channel IDs
  to context strings that get prepended to the user's prompt. This lets
  different channels have different agent behavior, e.g. an alerts channel
  gets "debug the alert, be concise" while a support channel gets "explain
  things simply for non-technical users".
  
  Context is applied on new sessions; follow-ups inherit it from the
  conversation history.
  
  https://claude.ai/code/session_01BfEfaKPMDBgZ2UYEyMB6RR
  