### PR TITLE
Fix Slack session restore after container restart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,10 @@ Config is loaded from `.env` via Pydantic Settings (see `app/config.py`). Projec
 - Or prefix commands with the venv Python: `.venv/bin/python`
 - The PATH may not include uv by default - use `$HOME/.local/bin/uv` if needed
 
+## Pull Requests
+
+Keep PR descriptions short — a couple of sentences max. Don't repeat the diff in prose.
+
 ## Package Management
 
 - Use **uv** for Python package management

--- a/app/core/session_manager.py
+++ b/app/core/session_manager.py
@@ -359,9 +359,10 @@ class SessionManager:
                     continue
 
                 # Create a partial ActiveSession that can be resumed on follow-up
+                # Use the adapter's service_name so get_sessions_for_service() matches
                 self._active_sessions[external_id] = ActiveSession(
                     external_session_id=metadata["external_session_id"],
-                    service_name=metadata["service_name"],
+                    service_name=adapter.service_name,
                     adapter=adapter,
                     acp_session=None,  # Will be created on follow-up
                     update_router=None,  # Will be created on follow-up

--- a/app/services/slack/adapter.py
+++ b/app/services/slack/adapter.py
@@ -279,10 +279,10 @@ class SlackAdapter:
         # Mark this thread as active (will persist after session ends)
         self._active_threads.add((mention_event.channel, thread_ts))
 
-        # Create bridge request (service_name stays "slack" for project mapping)
+        # Create bridge request
         request = BridgeSessionRequest(
             external_session_id=session_id,
-            service_name="slack",
+            service_name=self.service_name,
             prompt=thread_context + prompt,
             agent_name=self._agent_name,
             descriptive_name=slugify(prompt[:60]),


### PR DESCRIPTION
After a restart, follow-up messages in Slack threads created new sessions instead of resuming. The service_name mismatch between "slack" and "slack:claude" meant the adapter couldn't find its restored sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)